### PR TITLE
✨ update : uuid db 저장 (중간저장)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,7 @@ model Users {
   id        String    @unique @map("id")
   password  String    @map("password")
   score     Int       @default(0) @map("score")
+  uuid      String    @default("") @map("uuid")
   createdAt DateTime  @default(now()) @map("createdAt")
   updatedAt DateTime  @updatedAt @map("updatedAt")
 

--- a/src/handlers/helper.js
+++ b/src/handlers/helper.js
@@ -11,7 +11,6 @@ export const handleDisconnect = (socket, uuid) => {
 export const handleConnection = (socket, userUUID) => {
   console.log(`New user connected: ${userUUID} with socket ID ${socket.id}`);
   console.log('Current users:', getUsers());
-
   socket.emit('connection', { uuid: userUUID });
 };
 

--- a/src/handlers/register.handler.js
+++ b/src/handlers/register.handler.js
@@ -1,14 +1,15 @@
 import { v4 as uuidv4 } from 'uuid';
 import { addUser } from '../models/user.model.js';
 import { handleDisconnect, handleConnection, handleEvent } from './helper.js';
+import { prisma } from '../utils/prisma/index.js';
 
 const registerHandler = async (io) => {
   await io.on('connection', async (socket) => {
     // 최초 커넥션을 맺은 이후 발생하는 각종 이벤트를 처리하는 곳
-    console.log(socket.handshake.query);
-    // UUID 생성
+
     const userUUID = socket.handshake.query.uuid != 'null' ? socket.handshake.query.uuid : uuidv4();
-    await addUser({ uuid: userUUID, socketId: socket.id }); // 사용자 추가
+    const token = socket.handshake.query.token;
+    await addUser({ uuid: userUUID, socketId: socket.id, token }); // 사용자 추가
 
     // 접속시 유저 정보 생성 이벤트 처리
     await handleConnection(socket, userUUID);

--- a/src/middlewares/auth.middleware.js
+++ b/src/middlewares/auth.middleware.js
@@ -1,0 +1,26 @@
+import { prisma } from '../utils/prisma/index.js';
+import jwt from 'jsonwebtoken';
+
+export const authMiddleware = async (cookie) => {
+  try {
+    if (!cookie) throw new Error('토큰이 존재하지 않습니다.');
+
+    const [tokenType, token] = cookie.split(' ');
+
+    if (tokenType !== 'Bearer') throw new Error('토큰 타입이 일치하지 않습니다.');
+
+    const decodedToken = jwt.verify(token, 'custom-secret-key');
+    const userId = decodedToken.userId;
+
+    const user = await prisma.users.findFirst({
+      where: { userId: +userId },
+    });
+    if (!user) {
+      throw new Error('토큰 사용자가 존재하지 않습니다.');
+    }
+
+    return user;
+  } catch (err) {
+    console.log(err);
+  }
+};

--- a/src/models/user.model.js
+++ b/src/models/user.model.js
@@ -1,10 +1,26 @@
+import { prisma } from '../utils/prisma/index.js';
+import { authMiddleware } from '../middlewares/auth.middleware.js';
+
 const users = [];
 
 // 서버 메모리에 유저의 세션(소켓ID)을 저장
 // 이때 유저는 객체 형태로 저장
 // { uuid: string; socketId: string; };
-export const addUser = (user) => {
-  users.push(user);
+export const addUser = async (user) => {
+  const data = {
+    uuid: user.uuid,
+    socketId: user.socketId,
+  };
+  users.push(data);
+
+  const userData = await authMiddleware(user.token);
+  const { userId } = userData;
+  await prisma.users.update({
+    where: { userId: userId },
+    data: {
+      uuid: user.uuid,
+    },
+  });
 };
 
 // 배열에서 유저 삭제

--- a/tower_defense_client/src/game.js
+++ b/tower_defense_client/src/game.js
@@ -3,6 +3,7 @@ import { Monster } from './monster.js';
 import { Tower } from './tower.js';
 import { CLIENT_VERSION } from './Constants.js';
 import { handleResponse } from '../handlers/helper.js';
+import { prisma } from '../../src/utils/prisma/index.js';
 
 /* 
   어딘가에 엑세스 토큰이 저장이 안되어 있다면 로그인을 유도하는 코드를 여기에 추가해주세요!
@@ -240,8 +241,15 @@ function initGame() {
   gameLoop(); // 게임 루프 최초 실행
   isInitGame = true;
 }
+
 let userId = localStorage.getItem('userId');
-console.log(userId);
+function getCookieValue(name) {
+  const regex = new RegExp(`(^| )${name}=([^;]+)`);
+  const match = document.cookie.match(regex);
+  if (match) {
+    return match[2];
+  }
+}
 // 이미지 로딩 완료 후 서버와 연결하고 게임 초기화
 Promise.all([
   new Promise((resolve) => (backgroundImage.onload = resolve)),
@@ -255,6 +263,7 @@ Promise.all([
     query: {
       clientVersion: CLIENT_VERSION,
       uuid: userId,
+      token: getCookieValue('authorization'),
     },
   });
 


### PR DESCRIPTION
245 줄 : 게임 시작시 userId 값을 로컬스토리지에서 읽는다.
265 줄 : 245줄에서 읽은 userId 값을 서버에 socket.handshake.query 로 내보낸다. ---------
register.handler.js 파일에서
10줄 : query의 uuid 값이 'null' 이면 새로운 uuid 생성, 값이 있으면 query의 uuid 값을 그대로 addUser에 전달 -----------
user.model.js 파일에서
16줄 : query에서 받아온 토큰값을 인증미들웨어를 거쳐 userId 값을 찾는다.
18줄 : 찾은 userId 값을 기준으로 uuid 값을 query에 받아온 uuid 를 저장 ------------
문제점
1. 로컬스토리지에 uuid 값을 저장하므로 새로운 아이디로 접속시 같은 uuid 로 값이 db에 저장되는 현상

resolve #25